### PR TITLE
Add web updater smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A real-time firmware for animating a HUB75 LED matrix Protogen mask with sensor-
 - 🤖 [GitHub Copilot Integration](#github-copilot-integration)
 - 🤝 [Contributing](#contributing)
 - 📜 [License](#license)
+- 🌐 [Web Firmware Updater](#web-firmware-updater)
 
 ## Features
 - 20+ animated faces and effects including plasma, flame, fluid, circle eyes, spiral overlays, starfields, and scrolling text purpose-built for dual 64×32 HUB75 panels.
@@ -77,6 +78,11 @@ Additional PlatformIO environments are defined in `platformio.ini`, including a 
 - Run the GoogleTest suite with coverage via `pio test -e codeql`.
 - Execute Unity-based module tests with `pio test -e native2`.
 - Coverage reports and additional tooling scripts are located under `test/` and `test/test_coverage/`.
+- Lightweight smoke tests for the Web Bluetooth firmware updater can run without PlatformIO: `python -m unittest discover docs/firmware-updater/tests`.
+
+## Web Firmware Updater
+- A browser-based OTA helper lives at `docs/firmware-updater/index.html`. Serve the folder over HTTPS or `http://localhost` (for example, `python -m http.server 8000` from the repo root) because Web Bluetooth is blocked on `file://` origins. Open the page in a supported browser (Chrome or Edge), click **Connect** to choose your LumiFur controller, select a compiled `.bin` firmware file, and press **Upload Firmware** to stream it over the OTA characteristic (`01931c44-3867-7427-96ab-8d7ac0ae09ee`).
+- Keep the page open during transfer; the device will reboot automatically after the update finishes.
 
 ## GitHub Copilot Integration
 Developer onboarding guides for GitHub Copilot live in `docs/COPILOT_SETUP.md` and `docs/COPILOT_USAGE.md`, with tailored instructions for embedded patterns, animation workflows, and testing expectations.

--- a/docs/firmware-updater/app.js
+++ b/docs/firmware-updater/app.js
@@ -1,0 +1,211 @@
+const SERVICE_UUID = "01931c44-3867-7740-9867-c822cb7df308";
+const OTA_CHARACTERISTIC_UUID = "01931c44-3867-7427-96ab-8d7ac0ae09ee";
+const CHUNK_SIZE = 180; // Conservative payload per BLE packet
+
+const connectBtn = document.getElementById("connect-btn");
+const uploadBtn = document.getElementById("upload-btn");
+const fileInput = document.getElementById("firmware-file");
+const fileLabel = document.getElementById("file-label");
+const fileHelper = document.getElementById("file-helper");
+const connectionStatus = document.getElementById("connection-status");
+const deviceName = document.getElementById("device-name");
+const progressBar = document.getElementById("progress-bar");
+const progressLabel = document.getElementById("progress-label");
+const logEl = document.getElementById("log");
+
+let bluetoothDevice;
+let otaCharacteristic;
+let firmwareFile;
+let isUploading = false;
+
+function log(message, type = "info") {
+  const entry = document.createElement("p");
+  entry.textContent = message;
+  entry.className = type;
+  logEl.appendChild(entry);
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+function setProgress(percent, label) {
+  progressBar.style.width = `${percent}%`;
+  progressLabel.textContent = label;
+}
+
+function setConnectedState(name) {
+  connectionStatus.textContent = "Connected";
+  connectionStatus.classList.remove("error");
+  connectionStatus.classList.add("success");
+  deviceName.textContent = name || "LumiFur Controller";
+  uploadBtn.disabled = !firmwareFile;
+  connectBtn.textContent = "Reconnect";
+}
+
+function setDisconnectedState(reason = "Disconnected") {
+  connectionStatus.textContent = reason;
+  connectionStatus.classList.remove("success");
+  connectionStatus.classList.add("error");
+  deviceName.textContent = "—";
+  uploadBtn.disabled = true;
+  isUploading = false;
+  connectBtn.textContent = "Connect";
+  otaCharacteristic = undefined;
+  bluetoothDevice = undefined;
+  setProgress(0, "Waiting to start…");
+}
+
+function handleNotifications(event) {
+  const value = event.target.value;
+  if (!value || value.byteLength < 1) return;
+
+  const view = new DataView(value.buffer);
+  const code = view.getUint8(0);
+
+  if (code === 0x01 && value.byteLength >= 2 && view.getUint8(1) === 0x00) {
+    log("OTA session started", "success");
+  } else if (code === 0x03 && value.byteLength >= 2 && view.getUint8(1) === 0x00) {
+    log("OTA complete. Device will reboot.", "success");
+    setProgress(100, "Upload complete");
+    uploadBtn.disabled = false;
+    isUploading = false;
+  } else if (code === 0x04 && value.byteLength >= 2 && view.getUint8(1) === 0x00) {
+    log("OTA aborted by device", "error");
+    isUploading = false;
+    uploadBtn.disabled = false;
+  } else if (code === 0xff && value.byteLength >= 2) {
+    log(`Device reported error 0x${view.getUint8(1).toString(16).padStart(2, "0")}`, "error");
+    isUploading = false;
+    uploadBtn.disabled = false;
+  }
+}
+
+async function connect() {
+  if (!navigator.bluetooth) {
+    log("Web Bluetooth is not available in this browser.", "error");
+    return;
+  }
+
+  if (!window.isSecureContext) {
+    log("A secure context is required. Serve this page via https:// or http://localhost.", "error");
+    return;
+  }
+
+  if (bluetoothDevice?.gatt?.connected && otaCharacteristic) {
+    setConnectedState(bluetoothDevice.name);
+    log("Already connected to the device.");
+    return;
+  }
+
+  try {
+    bluetoothDevice = await navigator.bluetooth.requestDevice({
+      filters: [{ services: [SERVICE_UUID] }],
+      optionalServices: [SERVICE_UUID],
+    });
+
+    bluetoothDevice.addEventListener("gattserverdisconnected", () => {
+      log("Bluetooth connection lost.", "error");
+      setDisconnectedState("Disconnected");
+    });
+
+    const server = await bluetoothDevice.gatt.connect();
+    const service = await server.getPrimaryService(SERVICE_UUID);
+    otaCharacteristic = await service.getCharacteristic(OTA_CHARACTERISTIC_UUID);
+    await otaCharacteristic.startNotifications();
+    otaCharacteristic.addEventListener("characteristicvaluechanged", handleNotifications);
+
+    setConnectedState(bluetoothDevice.name);
+    log("Connected to device and ready for OTA.", "success");
+  } catch (error) {
+    if (error.name === "NotFoundError") {
+      log("Device selection canceled.");
+      return;
+    }
+
+    log(`Connection failed: ${error.message}`, "error");
+    setDisconnectedState("Failed to connect");
+  }
+}
+
+function buildStartPacket(size) {
+  const buffer = new ArrayBuffer(5);
+  const view = new DataView(buffer);
+  view.setUint8(0, 0x01);
+  view.setUint32(1, size, true);
+  return buffer;
+}
+
+async function upload() {
+  if (!otaCharacteristic || !bluetoothDevice?.gatt.connected) {
+    log("Connect to the device before uploading.", "error");
+    return;
+  }
+  if (!firmwareFile) {
+    log("Choose a firmware .bin file first.", "error");
+    return;
+  }
+  if (isUploading) return;
+
+  isUploading = true;
+  uploadBtn.disabled = true;
+  setProgress(0, "Sending start command…");
+  log(`Beginning OTA upload (${firmwareFile.size} bytes).`);
+
+  try {
+    const firmwareData = new Uint8Array(await firmwareFile.arrayBuffer());
+
+    await otaCharacteristic.writeValueWithResponse(buildStartPacket(firmwareData.byteLength));
+
+    for (let offset = 0; offset < firmwareData.length; offset += CHUNK_SIZE) {
+      const remaining = firmwareData.length - offset;
+      const chunkLength = Math.min(remaining, CHUNK_SIZE);
+      const packet = new Uint8Array(chunkLength + 1);
+      packet[0] = 0x02; // DATA
+      packet.set(firmwareData.subarray(offset, offset + chunkLength), 1);
+
+      await otaCharacteristic.writeValueWithResponse(packet);
+
+      const percent = Math.min(99, Math.round(((offset + chunkLength) / firmwareData.length) * 100));
+      setProgress(percent, `Sending firmware… ${percent}%`);
+    }
+
+    setProgress(99, "Finalizing update…");
+    await otaCharacteristic.writeValueWithResponse(Uint8Array.of(0x03)); // END
+    log("End command sent. Waiting for device to reboot…");
+  } catch (error) {
+    log(`Upload failed: ${error.message}`, "error");
+    isUploading = false;
+    uploadBtn.disabled = false;
+  }
+}
+
+fileInput.addEventListener("change", (event) => {
+  const [file] = event.target.files;
+  firmwareFile = file;
+
+  if (file) {
+    fileLabel.textContent = file.name;
+    fileHelper.textContent = `${file.size.toLocaleString()} bytes selected`;
+    uploadBtn.disabled = !otaCharacteristic;
+  } else {
+    fileLabel.textContent = "Choose .bin file";
+    fileHelper.textContent = "No file selected";
+    uploadBtn.disabled = true;
+  }
+});
+
+if (!navigator.bluetooth) {
+  connectionStatus.textContent = "Unsupported";
+  connectionStatus.classList.add("error");
+  connectBtn.disabled = true;
+  log("This browser does not support Web Bluetooth.", "error");
+} else if (!window.isSecureContext) {
+  log("Serve this page from https:// or http://localhost to enable Web Bluetooth.", "error");
+}
+
+window.addEventListener("beforeunload", () => {
+  if (bluetoothDevice?.gatt?.connected) {
+    bluetoothDevice.gatt.disconnect();
+  }
+});
+
+connectBtn.addEventListener("click", connect);
+uploadBtn.addEventListener("click", upload);

--- a/docs/firmware-updater/index.html
+++ b/docs/firmware-updater/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>LumiFur Firmware Updater</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>LumiFur Firmware Updater</h1>
+    <p class="lede">Update your LumiFur Controller over Bluetooth Low Energy (BLE) using a Web Bluetooth–enabled browser.</p>
+  </header>
+
+  <main>
+    <section class="card">
+      <h2>1. Prepare</h2>
+      <ul>
+        <li>Use Chrome, Edge, or another browser that supports Web Bluetooth.</li>
+        <li>Power on your LumiFur controller and make sure Bluetooth is enabled.</li>
+        <li>Have the compiled firmware <code>.bin</code> file ready.</li>
+      </ul>
+    </section>
+
+    <section class="card grid">
+      <div>
+        <h2>2. Connect</h2>
+        <p>Connect to the LumiFur controller's BLE service.</p>
+        <button id="connect-btn">Connect</button>
+        <dl class="meta">
+          <div>
+            <dt>Status</dt>
+            <dd id="connection-status">Disconnected</dd>
+          </div>
+          <div>
+            <dt>Device</dt>
+            <dd id="device-name">—</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div>
+        <h2>3. Select Firmware</h2>
+        <p>Choose the firmware binary to send to the device.</p>
+        <label class="file-picker">
+          <input type="file" id="firmware-file" accept=".bin" />
+          <span id="file-label">Choose .bin file</span>
+        </label>
+        <p class="helper" id="file-helper">No file selected</p>
+      </div>
+    </section>
+
+    <section class="card">
+      <div class="upload-header">
+        <div>
+          <h2>4. Upload</h2>
+          <p>Start the over-the-air (OTA) update. Keep the page open until completion.</p>
+        </div>
+        <button id="upload-btn" disabled>Upload Firmware</button>
+      </div>
+
+      <div class="progress" aria-live="polite">
+        <div id="progress-bar"></div>
+        <span id="progress-label">Waiting to start…</span>
+      </div>
+
+      <div class="log" id="log" aria-live="polite"></div>
+    </section>
+  </main>
+
+  <footer>
+    <p>Need help? Ensure the device advertises the <code>01931c44-3867-7740-9867-c822cb7df308</code> service and move closer to your computer if the connection is unstable.</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/docs/firmware-updater/styles.css
+++ b/docs/firmware-updater/styles.css
@@ -1,0 +1,217 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --card: #111827;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --accent: #60a5fa;
+  --danger: #f87171;
+  --success: #4ade80;
+  --border: rgba(255, 255, 255, 0.08);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(96, 165, 250, 0.08), transparent 25%),
+    radial-gradient(circle at 80% 0%, rgba(74, 222, 128, 0.08), transparent 25%),
+    var(--bg);
+  color: var(--text);
+  padding: 2.5rem 1.5rem 3rem;
+  line-height: 1.6;
+}
+
+header {
+  text-align: center;
+  max-width: 900px;
+  margin: 0 auto 2rem;
+}
+
+h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.35rem;
+}
+
+main {
+  max-width: 980px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 15px 50px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(8px);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  align-items: start;
+}
+
+ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1.25rem;
+  color: var(--muted);
+}
+
+button {
+  appearance: none;
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #22c55e);
+  color: #0b1220;
+  padding: 0.75rem 1.2rem;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+  box-shadow: 0 10px 30px rgba(96, 165, 250, 0.35);
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 36px rgba(96, 165, 250, 0.45);
+}
+
+button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.5rem 1rem;
+  margin: 1rem 0 0;
+}
+
+.meta dt {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-bottom: 0.1rem;
+}
+
+.meta dd {
+  margin: 0;
+  font-weight: 700;
+}
+
+.file-picker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  cursor: pointer;
+  color: var(--text);
+}
+
+.file-picker input {
+  display: none;
+}
+
+#file-label {
+  font-weight: 700;
+}
+
+.helper {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.upload-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.progress {
+  position: relative;
+  margin: 1rem 0;
+  height: 16px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+#progress-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 0%;
+  background: linear-gradient(135deg, #22c55e, #2563eb);
+  transition: width 0.2s ease;
+}
+
+#progress-label {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.log {
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+  min-height: 120px;
+  font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  color: var(--muted);
+  overflow-y: auto;
+  max-height: 280px;
+}
+
+.log p {
+  margin: 0.15rem 0;
+}
+
+.log .info { color: var(--muted); }
+.log .success { color: var(--success); }
+.log .error { color: var(--danger); }
+
+footer {
+  max-width: 900px;
+  margin: 1.5rem auto 0;
+  text-align: center;
+  color: var(--muted);
+}
+
+.lede {
+  color: var(--muted);
+  margin: 0.25rem auto 0;
+  max-width: 620px;
+}
+
+@media (max-width: 600px) {
+  body { padding: 1.5rem 1rem; }
+  .card { padding: 1rem 1.1rem; }
+}

--- a/docs/firmware-updater/tests/test_updater_page.py
+++ b/docs/firmware-updater/tests/test_updater_page.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class FirmwareUpdaterPageTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.index_html = (ROOT / "index.html").read_text(encoding="utf-8")
+        self.app_js = (ROOT / "app.js").read_text(encoding="utf-8")
+
+    def test_index_contains_core_elements(self):
+        """The updater UI should present primary controls."""
+        for marker in ["connect-btn", "firmware-file", "upload-btn", "progress-bar", "log"]:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.index_html)
+
+    def test_app_logs_key_states(self):
+        """Ensure the OTA workflow logs the main connection and upload states."""
+        for marker in [
+          "Connected to device and ready for OTA.",
+          "Connect to the device before uploading.",
+          "Beginning OTA upload",
+          "End command sent. Waiting for device to reboot",
+        ]:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, self.app_js)
+
+    def test_app_has_disconnect_guard(self):
+        self.assertRegex(
+            self.app_js,
+            r"gattserverdisconnected",
+            msg="Disconnect cleanup listener missing",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add lightweight Python smoke tests to cover key Web Bluetooth firmware updater UI and log states
- document running the new updater smoke tests without PlatformIO

## Testing
- python -m unittest discover docs/firmware-updater/tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932ee5b7bbc832f9e188097337d2af9)