### PR TITLE
Refactor deploy workflow to dynamically locate firmware updater direc…

### DIFF
--- a/.github/workflows/deploy-web-updater.yml
+++ b/.github/workflows/deploy-web-updater.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'docs/firmware-updater/**'
+      - 'firmware-updater/**'
       - '.github/workflows/deploy-web-updater.yml'
   workflow_dispatch:
 
@@ -24,13 +25,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Locate firmware updater directory
+        id: updater-dir
+        shell: bash
+        run: |
+          if [ -d "docs/firmware-updater" ]; then
+            echo "path=docs/firmware-updater" >> "$GITHUB_OUTPUT"
+          elif [ -d "firmware-updater" ]; then
+            echo "path=firmware-updater" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Firmware updater directory not found. Expected docs/firmware-updater or firmware-updater"
+            exit 1
+          fi
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
       - name: Upload firmware updater artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/firmware-updater
+          path: ${{ steps.updater-dir.outputs.path }}
 
   deploy:
     needs: build


### PR DESCRIPTION
This pull request updates the deployment workflow for the web firmware updater to support both the old and new directory structures. The workflow now dynamically locates the firmware updater directory, allowing for greater flexibility and preventing deployment failures if the directory moves.

**Workflow improvements:**

* The workflow trigger now includes both `docs/firmware-updater/**` and `firmware-updater/**` paths, so deployments run when changes are made in either location.
* A new step has been added to dynamically locate the firmware updater directory (`docs/firmware-updater` or `firmware-updater`) and set the correct path for subsequent steps, ensuring the deployment works regardless of which directory is present.
* The artifact upload step now uses the dynamically determined path, making the workflow more robust to directory changes.