### PR TITLE
Environment fix for github-pages

### DIFF
--- a/.github/workflows/deploy-web-updater.yml
+++ b/.github/workflows/deploy-web-updater.yml
@@ -49,6 +49,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    environment: github-pages  # Add this line
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
This pull request makes a small configuration update to the deployment workflow. The change specifies the deployment environment for the deploy job, which can help with environment protection rules and visibility in GitHub Actions.

- Set the `environment` for the `deploy` job to `github-pages` in `.github/workflows/deploy-web-updater.yml`.