### PR TITLE
Dev

### DIFF
--- a/.github/workflows/deploy-web-updater.yml
+++ b/.github/workflows/deploy-web-updater.yml
@@ -49,7 +49,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment: github-pages  # Add this line
+    environment: github-pages
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Additional PlatformIO environments are defined in `platformio.ini`, including a 
 
 ## Web Firmware Updater
 - A browser-based OTA helper lives at `docs/firmware-updater/index.html`. Serve the folder over HTTPS or `http://localhost` (for example, `python -m http.server 8000` from the repo root) because Web Bluetooth is blocked on `file://` origins. Open the page in a supported browser (Chrome or Edge), click **Connect** to choose your LumiFur controller, select a compiled `.bin` firmware file, and press **Upload Firmware** to stream it over the OTA characteristic (`01931c44-3867-7427-96ab-8d7ac0ae09ee`).
+- Production builds are published automatically to GitHub Pages at [https://stef1949.github.io/LumiFur_Controller/](https://stef1949.github.io/LumiFur_Controller/); the root URL redirects to the `firmware-updater/` UI.
 - Keep the page open during transfer; the device will reboot automatically after the update finishes.
 
 ## GitHub Copilot Integration

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=firmware-updater/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LumiFur Firmware Updater Redirect</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+        background: #0f172a;
+        color: #e5e7eb;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        margin: 0;
+      }
+      main {
+        text-align: center;
+        padding: 1.5rem;
+      }
+      a {
+        color: #60a5fa;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Redirecting to the Firmware Updater</h1>
+      <p>
+        If you are not redirected automatically,
+        <a href="firmware-updater/">open the LumiFur Firmware Updater</a>.
+      </p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
This pull request improves the user experience and documentation for the LumiFur Controller web firmware updater by adding an automatic redirect from the root URL to the firmware updater UI and clarifying deployment details. The most important changes are as follows:

**Web Updater User Experience:**

* Added a new `docs/index.html` file that automatically redirects users from the root URL to the `firmware-updater/` UI, with a styled fallback message and manual link in case the redirect fails.

**Documentation Updates:**

* Updated the `README.md` to note that production builds are now published automatically to GitHub Pages, and that the root URL redirects to the firmware updater UI.

**Workflow Configuration:**

* Cleaned up the `environment` line in the GitHub Actions deployment workflow for GitHub Pages, removing an unnecessary comment.