### PR TITLE
dev main merge

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -159,7 +159,7 @@ jobs:
     name: Create Release Bundle
     needs: build-firmware
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release'
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -9,6 +9,12 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
+env:
+  RELEASE_REF_NAME: ${{ github.ref_name || github.event.release.tag_name || github.sha }}
+
 jobs:
   build-firmware:
     name: Build Firmware for ${{ matrix.environment }}
@@ -169,6 +175,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: all-firmware/
+          pattern: firmware-*
           
       - name: Create release bundle
         run: |
@@ -176,8 +183,10 @@ jobs:
           mkdir -p release-bundle
           
           # Process each environment's artifacts
+          found_env=false
           for env_dir in all-firmware/firmware-*; do
             if [ -d "$env_dir" ]; then
+              found_env=true
               env_name=$(basename "$env_dir" | sed 's/firmware-//')
               echo "Processing $env_name artifacts..."
               
@@ -188,12 +197,16 @@ jobs:
               cp -r "$env_dir"/* "release-bundle/$env_name/"
             fi
           done
+          if [ "$found_env" = false ]; then
+            echo "No firmware artifacts were downloaded."
+            exit 1
+          fi
           
           # Create a master build info file
           echo "LumiFur Controller Firmware Release" > release-bundle/README.txt
           echo "====================================" >> release-bundle/README.txt
           echo "" >> release-bundle/README.txt
-          echo "Release: ${GITHUB_REF_NAME}" >> release-bundle/README.txt
+          echo "Release: ${RELEASE_REF_NAME}" >> release-bundle/README.txt
           echo "Built: $(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> release-bundle/README.txt
           echo "Commit: $(git rev-parse --short HEAD)" >> release-bundle/README.txt
           echo "" >> release-bundle/README.txt
@@ -219,18 +232,18 @@ jobs:
       - name: Create release archive
         run: |
           cd release-bundle
-          tar -czf ../lumifur-firmware-${GITHUB_REF_NAME}.tar.gz *
+          tar -czf ../lumifur-firmware-${RELEASE_REF_NAME}.tar.gz *
           cd ..
-          zip -r lumifur-firmware-${GITHUB_REF_NAME}.zip release-bundle/
+          zip -r lumifur-firmware-${RELEASE_REF_NAME}.zip release-bundle/
           
           # Show archive info
           echo "Created archives:"
-          ls -la lumifur-firmware-${GITHUB_REF_NAME}.*
+          ls -la lumifur-firmware-${RELEASE_REF_NAME}.*
           
       - name: Upload release bundle
         uses: actions/upload-artifact@v4
         with:
-          name: lumifur-firmware-release-${{ github.ref_name }}
+          name: lumifur-firmware-release-${{ env.RELEASE_REF_NAME }}
           path: |
             lumifur-firmware-*.tar.gz
             lumifur-firmware-*.zip
@@ -247,7 +260,7 @@ jobs:
       - name: Download release bundle
         uses: actions/download-artifact@v4
         with:
-          name: lumifur-firmware-release-${{ github.ref_name }}
+          name: lumifur-firmware-release-${{ env.RELEASE_REF_NAME }}
           
       - name: Attach to release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This pull request updates the `build-firmware.yml` GitHub Actions workflow to improve release handling, artifact management, and environment variable usage. The changes make the workflow more robust and flexible when creating and uploading firmware release bundles.

**Release and artifact handling improvements:**

* Added a `permissions` section with `contents: write` and defined a new environment variable `RELEASE_REF_NAME` to consistently identify the release name, improving reliability in different trigger scenarios.
* Updated conditional logic so the "Create Release Bundle" job runs on both tag pushes and release events, ensuring releases are built in more scenarios.

**Artifact processing enhancements:**

* Modified artifact download to use a `pattern` for firmware artifacts, and added logic to check if any firmware artifacts were found, failing early if none are present. [[1]](diffhunk://#diff-002f0cf6de5b59906143def2851a94115b1ce39b58995b2ce87ec84efc63d3c2R178-R189) [[2]](diffhunk://#diff-002f0cf6de5b59906143def2851a94115b1ce39b58995b2ce87ec84efc63d3c2R200-R209)

**Consistent environment variable usage:**

* Replaced all uses of `${GITHUB_REF_NAME}` with the new `${RELEASE_REF_NAME}` variable for naming release files and artifacts, ensuring consistent naming regardless of the event source. [[1]](diffhunk://#diff-002f0cf6de5b59906143def2851a94115b1ce39b58995b2ce87ec84efc63d3c2R200-R209) [[2]](diffhunk://#diff-002f0cf6de5b59906143def2851a94115b1ce39b58995b2ce87ec84efc63d3c2L222-R246) [[3]](diffhunk://#diff-002f0cf6de5b59906143def2851a94115b1ce39b58995b2ce87ec84efc63d3c2L250-R263)