### PR TITLE
Add BLE pairing passkey management and reset functionality

### DIFF
--- a/src/ble/ble_state.cpp
+++ b/src/ble/ble_state.cpp
@@ -4,6 +4,8 @@
 bool deviceConnected = false;
 bool oldDeviceConnected = false;
 bool devicePairing = false;
+uint32_t pairingPasskey = 0;
+bool pairingPasskeyValid = false;
 
 NimBLEServer *pServer = nullptr;
 NimBLECharacteristic *pCharacteristic = nullptr;

--- a/src/ble/ble_state.h
+++ b/src/ble/ble_state.h
@@ -2,6 +2,7 @@
 #define BLE_STATE_H
 
 #include <NimBLEDevice.h>
+#include <cstdint>
 #include <string>
 
 #include "ble/ble_ota.h"
@@ -11,6 +12,8 @@
 extern bool deviceConnected;
 extern bool oldDeviceConnected;
 extern bool devicePairing;
+extern uint32_t pairingPasskey;
+extern bool pairingPasskeyValid;
 
 extern NimBLEServer *pServer;
 extern NimBLECharacteristic *pCharacteristic;


### PR DESCRIPTION
This pull request significantly improves the BLE pairing experience by introducing dynamic passkey display, better state management, and a user-friendly way to reset BLE bonds using button input. The changes span BLE server logic, state tracking, display updates, and user interaction handling.

**BLE Pairing and Security Improvements:**

* Implemented dynamic passkey generation and display during BLE pairing, replacing the static passkey with a randomly generated one for each pairing session (`src/ble/ble_server.cpp`, `src/ble/ble_state.cpp`, `src/ble/ble_state.h`). [[1]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5R58-R75) [[2]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5R28) [[3]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5R37-R38) [[4]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5R87-R92) [[5]](diffhunk://#diff-d65a43c272946fe983ff1975d67344c784ae1ce89347482575c8dcd9b6a60a85R7-R8) [[6]](diffhunk://#diff-cd405884bb849cd83c0689814c51609d0b126f638a1e14ad819e3671ceae149cR15-R16)
* Updated BLE security IO capabilities to `DISPLAY_ONLY` to match the new passkey display approach (`src/main.cpp`).

**State Tracking Enhancements:**

* Added new global state variables (`pairingPasskey`, `pairingPasskeyValid`) to accurately track pairing status and passkey validity throughout the pairing process (`src/ble/ble_state.cpp`, `src/ble/ble_state.h`, `src/ble/ble_server.cpp`). [[1]](diffhunk://#diff-d65a43c272946fe983ff1975d67344c784ae1ce89347482575c8dcd9b6a60a85R7-R8) [[2]](diffhunk://#diff-cd405884bb849cd83c0689814c51609d0b126f638a1e14ad819e3671ceae149cR15-R16) [[3]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5R28) [[4]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5R37-R38) [[5]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5R87-R92)

**Display and User Interface Updates:**

* Added a new overlay function to visually show the current pairing passkey on the device display during pairing, ensuring users can easily see the code for secure pairing (`src/main.cpp`). [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R996-R1071) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R2208) [[3]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R3437)

**User Interaction and Bond Reset:**

* Enabled BLE bond reset and pairing restart by holding both hardware buttons for a configurable duration, providing a straightforward way for users to clear bonds and initiate new pairing (`src/main.cpp`). [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R3663-R3695) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L3572-R3705) [[3]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R824-R846) [[4]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R113)

**Codebase Maintenance:**

* Included necessary headers and improved type safety by adding `<cstdint>` and updating includes for ESP-IDF compatibility (`src/ble/ble_server.cpp`, `src/ble/ble_state.h`). [[1]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5R4-R5) [[2]](diffhunk://#diff-cd405884bb849cd83c0689814c51609d0b126f638a1e14ad819e3671ceae149cR5)