### PR TITLE
Dino game!  3

### DIFF
--- a/src/bitmaps.h
+++ b/src/bitmaps.h
@@ -21,6 +21,11 @@ static char dino [] PROGMEM = {
 	0x80, 0x08, 0x40, 0x28, 0x20, 0x38, 0x10, 0x40, 0x16, 0xc0, 0x16, 0x80, 0x12, 0x40, 0x1d, 0xc0
 };
 
+// 'cactus', 5x6px
+static char cactus [] PROGMEM = {
+	0xa0, 0xa8, 0x68, 0x30, 0x20, 0x70
+};
+
 // DVD-Video_Logo, 23x10px
 static char DvDLogo [] PROGMEM = {
 	0x7f, 0x83, 0xf8, 0x63, 0xc7, 0x8e, 0x63, 0x6d, 0x8e, 0x63, 0x79, 0x8c, 0x7e, 0x79, 0xf8, 0x78, 
@@ -318,7 +323,7 @@ static uint8_t spiralL[] PROGMEM = {
   0x00, 0x00, 0x00, 0x00
 };
 // 0buffer icons for transitions
-uint8_t bufferL[] = {
+static uint8_t bufferL[] = {
     0b00000000, 0b00000000,
                      0b00000000, 0b00000000,
                      0b00000000, 0b00000000,
@@ -328,7 +333,7 @@ uint8_t bufferL[] = {
                      0b00000000, 0b00000000,
                      0b00000000, 0b00000000
                      };
-uint8_t bufferR[] = {
+static uint8_t bufferR[] = {
     0b00000000, 0b00000000,
                      0b00000000, 0b00000000,
                      0b00000000, 0b00000000,
@@ -338,7 +343,7 @@ uint8_t bufferR[] = {
                      0b00000000, 0b00000000,
                      0b00000000, 0b00000000
                      };
-uint8_t fftIcon1[] = {
+static uint8_t fftIcon1[] = {
     0b00000000, 0b00000000,
                       0b00000000, 0b00000000,
                       0b00000000, 0b00000000,
@@ -348,7 +353,7 @@ uint8_t fftIcon1[] = {
                       0b00000000, 0b00000000,
                       0b00000000, 0b00000000
                       };
-uint8_t fftIcon2[] = {
+static uint8_t fftIcon2[] = {
     0b00000000, 0b00000000,
                       0b00000000, 0b00000000,
                       0b00000000, 0b00000000,
@@ -358,7 +363,7 @@ uint8_t fftIcon2[] = {
                       0b00000000, 0b00000000,
                       0b00000000, 0b00000000
                       };
-uint8_t fftIcon1L[] = {
+static uint8_t fftIcon1L[] = {
     0b00000000, 0b00000000,
                        0b00000000, 0b00000000,
                        0b00000000, 0b00000000,
@@ -368,7 +373,7 @@ uint8_t fftIcon1L[] = {
                        0b00000000, 0b00000000,
                        0b00000000, 0b00000000
                        };
-uint8_t fftIcon2L[] = {
+static uint8_t fftIcon2L[] = {
     0b00000000, 0b00000000,
                        0b00000000, 0b00000000,
                        0b00000000, 0b00000000,

--- a/src/ble/ble_metrics.cpp
+++ b/src/ble/ble_metrics.cpp
@@ -199,9 +199,9 @@ void updateLux()
         // Verify that the device is connected and the lux characteristic pointer is valid.
         if (deviceConnected && pLuxCharacteristic != nullptr)
         {
-            // Get current lux value from the APDS9960 sensor
-            extern uint16_t getRawClearChannelValue(); // Function from main.h
-            uint16_t currentLux = getRawClearChannelValue();
+            // Get current lux value from the APDS9960 sensor (in lux)
+            extern uint16_t getAmbientLuxU16(); // Function from main.h
+            uint16_t currentLux = getAmbientLuxU16();
 
             // Only send update if lux has changed significantly to avoid spam
             if (abs(static_cast<int>(currentLux) - static_cast<int>(lastSentLuxValue)) >= luxChangeThreshold)

--- a/src/ble/ble_server.cpp
+++ b/src/ble/ble_server.cpp
@@ -24,8 +24,7 @@ void ServerCallbacks::onConnect(NimBLEServer *pServer, NimBLEConnInfo &connInfo)
 
 void ServerCallbacks::onPairingRequest(NimBLEServer *pServer, NimBLEConnInfo &connInfo)
 {
-    devicePairing = true;
-    pairingPasskeyValid = false;
+    setPairingState(true, false, 0, false);
 #if DEBUG_BLE
     Serial.printf("Pairing request from: %s\n", connInfo.getAddress().toString().c_str());
 #endif
@@ -34,8 +33,16 @@ void ServerCallbacks::onPairingRequest(NimBLEServer *pServer, NimBLEConnInfo &co
 void ServerCallbacks::onDisconnect(NimBLEServer *pServer, NimBLEConnInfo &connInfo, int reason)
 {
     deviceConnected = false;
-    devicePairing = false;
-    pairingPasskeyValid = false;
+    setPairingState(false, false, 0, false);
+    const bool resetPending = isPairingResetPending();
+    if (resetPending && pServer->getConnectedCount() == 0)
+    {
+        const bool cleared = NimBLEDevice::deleteAllBonds();
+        setPairingResetPending(false);
+#if DEBUG_BLE
+        Serial.printf("BLE pairing reset: bonds cleared=%s\n", cleared ? "true" : "false");
+#endif
+    }
     NimBLEDevice::startAdvertising();
 #if DEBUG_BLE
     Serial.println("Client disconnected - advertising");
@@ -56,9 +63,7 @@ uint32_t ServerCallbacks::onPassKeyDisplay()
      *  or make your own static passkey as done here.
      */
     const uint32_t passkey = esp_random() % 1000000;
-    pairingPasskey = passkey;
-    pairingPasskeyValid = true;
-    devicePairing = true;
+    setPairingState(true, true, passkey, true);
 #if DEBUG_BLE
     Serial.printf("Server Passkey Display: %06" PRIu32 "\n", passkey);
 #endif
@@ -70,9 +75,7 @@ void ServerCallbacks::onConfirmPassKey(NimBLEConnInfo &connInfo, uint32_t pass_k
 #if DEBUG_BLE
     Serial.printf("The passkey YES/NO number: %" PRIu32 "\n", pass_key);
 #endif
-    pairingPasskey = pass_key;
-    pairingPasskeyValid = true;
-    devicePairing = true;
+    setPairingState(true, true, pass_key, true);
     /** Inject false if passkeys don't match. */
     NimBLEDevice::injectConfirmPasskey(connInfo, true);
 }
@@ -84,11 +87,9 @@ void ServerCallbacks::onAuthenticationComplete(NimBLEConnInfo &connInfo)
         Serial.printf("Encryption not established for: %s\n", connInfo.getAddress().toString().c_str());
         // Instead of disconnecting, you might choose to leave the connection or handle it gracefully.
         // For production use you can decide to force disconnect once you’re sure your client supports pairing.
-        devicePairing = false;
-        pairingPasskeyValid = false;
+        setPairingState(false, false, 0, false);
         return;
     }
-    devicePairing = false;
-    pairingPasskeyValid = false;
+    setPairingState(false, false, 0, false);
     Serial.printf("Secured connection to: %s\n", connInfo.getAddress().toString().c_str());
 }

--- a/src/ble/ble_state.h
+++ b/src/ble/ble_state.h
@@ -15,6 +15,19 @@ extern bool devicePairing;
 extern uint32_t pairingPasskey;
 extern bool pairingPasskeyValid;
 
+struct PairingSnapshot
+{
+  bool pairing;
+  bool passkeyValid;
+  uint32_t passkey;
+  bool resetPending;
+};
+
+PairingSnapshot getPairingSnapshot();
+void setPairingState(bool pairing, bool passkeyValid, uint32_t passkey, bool updatePasskey);
+void setPairingResetPending(bool pending);
+bool isPairingResetPending();
+
 extern NimBLEServer *pServer;
 extern NimBLECharacteristic *pCharacteristic;
 extern NimBLECharacteristic *pFaceCharacteristic;

--- a/src/core/mic/mic_config.h
+++ b/src/core/mic/mic_config.h
@@ -69,7 +69,7 @@
 #define MIC_OPEN_REBASE_ALPHA 0.02f
 
 #ifndef DEBUG_MICROPHONE
-#define DEBUG_MICROPHONE 1
+// #define DEBUG_MICROPHONE 1
 #endif
 
 #endif // MIC_CONFIG_H

--- a/src/dino_game.cpp
+++ b/src/dino_game.cpp
@@ -1,0 +1,329 @@
+#include "dino_game.h"
+
+#include <Arduino.h>
+#include <Fonts/TomThumb.h>
+#include <cstdio>
+
+#include "bitmaps.h"
+
+#ifdef VIRTUAL_PANE
+#include <ESP32-VirtualMatrixPanel-I2S-DMA.h>
+#else
+#include <ESP32-HUB75-MatrixPanel-I2S-DMA.h>
+#endif
+
+extern MatrixPanel_I2S_DMA *dma_display;
+extern void drawXbm565(int x, int y, int width, int height, const char *xbm, uint16_t color);
+
+namespace
+{
+constexpr int DINO_SPRITE_WIDTH = 15;
+constexpr int DINO_SPRITE_HEIGHT = 16;
+constexpr int DINO_CACTUS_WIDTH = 5;
+constexpr int DINO_CACTUS_HEIGHT = 6;
+constexpr int DINO_GROUND_THICKNESS = 1;
+constexpr int DINO_OBSTACLE_COUNT = 3;
+constexpr int DINO_GAME_DINO_X = 8;
+constexpr int DINO_HIT_INSET = 2;
+constexpr int DINO_CACTUS_HIT_INSET = 1;
+constexpr float DINO_GRAVITY = 200.0f;
+constexpr float DINO_JUMP_VELOCITY = -100.0f;
+constexpr float DINO_BASE_SPEED = 40.0f;
+constexpr float DINO_SPEED_BONUS_PER_PIXEL = 0.01f;
+constexpr float DINO_MAX_SPEED_BONUS = 25.0f;
+constexpr uint32_t DINO_MAX_FRAME_STEP_MS = 60;
+
+struct DinoGameState
+{
+  bool initialized = false;
+  bool gameOver = false;
+  volatile bool jumpQueued = false;
+  float dinoY = 0.0f;
+  float dinoVelY = 0.0f;
+  float distance = 0.0f;
+  uint32_t lastUpdateMs = 0;
+  uint32_t rngState = 0;
+  float obstaclesX[DINO_OBSTACLE_COUNT] = {};
+};
+
+static DinoGameState gDinoGame;
+
+static void getDinoGapRange(int displayWidth, int &minGap, int &maxGap)
+{
+  minGap = displayWidth / 3;
+  if (minGap < 28)
+  {
+    minGap = 28;
+  }
+  maxGap = displayWidth / 2;
+  if (maxGap < minGap + 12)
+  {
+    maxGap = minGap + 12;
+  }
+}
+
+static uint32_t nextDinoRand()
+{
+  // LCG constants for a simple, fast RNG local to dino view.
+  gDinoGame.rngState = gDinoGame.rngState * 1664525u + 1013904223u;
+  if (gDinoGame.rngState == 0)
+  {
+    gDinoGame.rngState = 0x6d2b79f5u;
+  }
+  return gDinoGame.rngState;
+}
+
+static int dinoRandRange(int minVal, int maxVal)
+{
+  if (maxVal <= minVal)
+  {
+    return minVal;
+  }
+  const uint32_t span = static_cast<uint32_t>(maxVal - minVal);
+  return minVal + static_cast<int>(nextDinoRand() % span);
+}
+
+static void updateDinoGame(uint32_t now)
+{
+  if (!dma_display)
+  {
+    gDinoGame.initialized = false;
+    return;
+  }
+
+  if (!gDinoGame.initialized)
+  {
+    resetDinoGame(now);
+    return;
+  }
+
+  const int displayWidth = dma_display->width();
+  const int displayHeight = dma_display->height();
+  const int groundY = displayHeight - DINO_GROUND_THICKNESS;
+  const float groundTop = static_cast<float>(groundY - DINO_SPRITE_HEIGHT);
+
+  if (gDinoGame.jumpQueued)
+  {
+    gDinoGame.jumpQueued = false;
+    if (gDinoGame.gameOver)
+    {
+      resetDinoGame(now);
+      return;
+    }
+    if (gDinoGame.dinoY >= groundTop - 0.5f)
+    {
+      gDinoGame.dinoVelY = DINO_JUMP_VELOCITY;
+    }
+  }
+
+  uint32_t deltaMs = now - gDinoGame.lastUpdateMs;
+  if (deltaMs > DINO_MAX_FRAME_STEP_MS)
+  {
+    deltaMs = DINO_MAX_FRAME_STEP_MS;
+  }
+  gDinoGame.lastUpdateMs = now;
+
+  const float dt = static_cast<float>(deltaMs) * 0.001f;
+
+  if (gDinoGame.gameOver)
+  {
+    if (gDinoGame.dinoY < groundTop)
+    {
+      gDinoGame.dinoVelY += DINO_GRAVITY * dt;
+      gDinoGame.dinoY += gDinoGame.dinoVelY * dt;
+      if (gDinoGame.dinoY > groundTop)
+      {
+        gDinoGame.dinoY = groundTop;
+        gDinoGame.dinoVelY = 0.0f;
+      }
+    }
+    return;
+  }
+
+  float speedBonus = gDinoGame.distance * DINO_SPEED_BONUS_PER_PIXEL;
+  if (speedBonus > DINO_MAX_SPEED_BONUS)
+  {
+    speedBonus = DINO_MAX_SPEED_BONUS;
+  }
+  const float speed = DINO_BASE_SPEED + speedBonus;
+
+  gDinoGame.distance += speed * dt;
+
+  gDinoGame.dinoVelY += DINO_GRAVITY * dt;
+  gDinoGame.dinoY += gDinoGame.dinoVelY * dt;
+  if (gDinoGame.dinoY >= groundTop)
+  {
+    gDinoGame.dinoY = groundTop;
+    gDinoGame.dinoVelY = 0.0f;
+  }
+
+  int minGap = 0;
+  int maxGap = 0;
+  getDinoGapRange(displayWidth, minGap, maxGap);
+
+  float farthestX = static_cast<float>(displayWidth);
+  for (int i = 0; i < DINO_OBSTACLE_COUNT; ++i)
+  {
+    if (gDinoGame.obstaclesX[i] > farthestX)
+    {
+      farthestX = gDinoGame.obstaclesX[i];
+    }
+  }
+
+  for (int i = 0; i < DINO_OBSTACLE_COUNT; ++i)
+  {
+    gDinoGame.obstaclesX[i] -= speed * dt;
+    if (gDinoGame.obstaclesX[i] + DINO_CACTUS_WIDTH < 0.0f)
+    {
+      float gap = static_cast<float>(dinoRandRange(minGap, maxGap));
+      gDinoGame.obstaclesX[i] = farthestX + gap;
+      farthestX = gDinoGame.obstaclesX[i];
+    }
+  }
+
+  const int dinoX = DINO_GAME_DINO_X;
+  const int dinoY = static_cast<int>(gDinoGame.dinoY + 0.5f);
+  const int dinoHitX = dinoX + DINO_HIT_INSET;
+  const int dinoHitY = dinoY + DINO_HIT_INSET;
+  const int dinoHitW = DINO_SPRITE_WIDTH - (DINO_HIT_INSET * 2);
+  const int dinoHitH = DINO_SPRITE_HEIGHT - (DINO_HIT_INSET * 2);
+
+  const int cactusY = groundY - DINO_CACTUS_HEIGHT;
+  const int cactusHitY = cactusY + DINO_CACTUS_HIT_INSET;
+  const int cactusHitH = DINO_CACTUS_HEIGHT - (DINO_CACTUS_HIT_INSET * 2);
+
+  for (int i = 0; i < DINO_OBSTACLE_COUNT; ++i)
+  {
+    const int cactusX = static_cast<int>(gDinoGame.obstaclesX[i] + 0.5f);
+    const int cactusHitX = cactusX + DINO_CACTUS_HIT_INSET;
+    const int cactusHitW = DINO_CACTUS_WIDTH - (DINO_CACTUS_HIT_INSET * 2);
+
+    if (dinoHitX < cactusHitX + cactusHitW &&
+        dinoHitX + dinoHitW > cactusHitX &&
+        dinoHitY < cactusHitY + cactusHitH &&
+        dinoHitY + dinoHitH > cactusHitY)
+    {
+      gDinoGame.gameOver = true;
+      gDinoGame.dinoVelY = 0.0f;
+      break;
+    }
+  }
+}
+} // namespace
+
+void resetDinoGame(uint32_t now)
+{
+  if (!dma_display)
+  {
+    gDinoGame.initialized = false;
+    return;
+  }
+
+  const int displayWidth = dma_display->width();
+  const int displayHeight = dma_display->height();
+  const int groundY = displayHeight - DINO_GROUND_THICKNESS;
+
+  gDinoGame.initialized = true;
+  gDinoGame.gameOver = false;
+  gDinoGame.jumpQueued = false;
+  gDinoGame.dinoVelY = 0.0f;
+  gDinoGame.dinoY = static_cast<float>(groundY - DINO_SPRITE_HEIGHT);
+  gDinoGame.distance = 0.0f;
+  gDinoGame.lastUpdateMs = now;
+  gDinoGame.rngState = (static_cast<uint32_t>(micros()) << 16) ^ now;
+  if (gDinoGame.rngState == 0)
+  {
+    gDinoGame.rngState = 0x6d2b79f5u;
+  }
+
+  int minGap = 0;
+  int maxGap = 0;
+  getDinoGapRange(displayWidth, minGap, maxGap);
+
+  float spawnX = static_cast<float>(displayWidth + 10);
+  for (int i = 0; i < DINO_OBSTACLE_COUNT; ++i)
+  {
+    spawnX += static_cast<float>(dinoRandRange(minGap, maxGap));
+    gDinoGame.obstaclesX[i] = spawnX;
+  }
+}
+
+void queueDinoJump()
+{
+  gDinoGame.jumpQueued = true;
+}
+
+void renderDinoGameView()
+{
+  if (!dma_display)
+  {
+    return;
+  }
+
+  const uint32_t now = millis();
+  updateDinoGame(now);
+
+  const int displayWidth = dma_display->width();
+  const int displayHeight = dma_display->height();
+  const int groundY = displayHeight - DINO_GROUND_THICKNESS;
+  const int dinoX = DINO_GAME_DINO_X;
+  const int dinoY = static_cast<int>(gDinoGame.dinoY + 0.5f);
+  const int cactusY = groundY - DINO_CACTUS_HEIGHT;
+
+  const uint16_t dinoColor = dma_display->color565(255, 255, 255);
+  const uint16_t cactusColor = dma_display->color565(0, 200, 0);
+  const uint16_t groundColor = dma_display->color565(80, 80, 80);
+  const uint16_t scoreColor = dma_display->color565(200, 200, 200);
+
+  dma_display->fillRect(0, groundY, displayWidth, DINO_GROUND_THICKNESS, groundColor);
+  drawXbm565(dinoX, dinoY, DINO_SPRITE_WIDTH, DINO_SPRITE_HEIGHT, dino, dinoColor);
+
+  for (int i = 0; i < DINO_OBSTACLE_COUNT; ++i)
+  {
+    const int cactusX = static_cast<int>(gDinoGame.obstaclesX[i] + 0.5f);
+    drawXbm565(cactusX, cactusY, DINO_CACTUS_WIDTH, DINO_CACTUS_HEIGHT, cactus, cactusColor);
+  }
+
+  char scoreText[12];
+  const uint32_t scoreValue = static_cast<uint32_t>(gDinoGame.distance);
+  snprintf(scoreText, sizeof(scoreText), "%lu", static_cast<unsigned long>(scoreValue));
+  dma_display->setFont(&TomThumb);
+  dma_display->setTextSize(1);
+  dma_display->setTextColor(scoreColor);
+  int16_t x1 = 0;
+  int16_t y1 = 0;
+  uint16_t w = 0;
+  uint16_t h = 0;
+  dma_display->getTextBounds(scoreText, 0, 0, &x1, &y1, &w, &h);
+  int scoreX = displayWidth - static_cast<int>(w) - 2;
+  if (scoreX < 0)
+  {
+    scoreX = 0;
+  }
+  const int scoreY = static_cast<int>(h) + 1;
+  dma_display->setCursor(scoreX, scoreY);
+  dma_display->print(scoreText);
+
+  if (gDinoGame.gameOver)
+  {
+    const char *message = "GAME OVER";
+    dma_display->setTextColor(dma_display->color565(255, 80, 80));
+    dma_display->setFont(&TomThumb);
+    dma_display->setTextSize(1);
+    int16_t msgX1 = 0;
+    int16_t msgY1 = 0;
+    uint16_t msgW = 0;
+    uint16_t msgH = 0;
+    dma_display->getTextBounds(message, 0, 0, &msgX1, &msgY1, &msgW, &msgH);
+    int textX = (displayWidth - static_cast<int>(msgW)) / 2;
+    int textY = (displayHeight / 2) + (static_cast<int>(msgH) / 2);
+    if (textY < static_cast<int>(msgH))
+    {
+      textY = static_cast<int>(msgH);
+    }
+    dma_display->setCursor(textX - msgX1, textY);
+    dma_display->print(message);
+    dma_display->setCursor(textX + msgX1, textY);
+    dma_display->print(message);
+  }
+}

--- a/src/dino_game.h
+++ b/src/dino_game.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <stdint.h>
+
+void resetDinoGame(uint32_t now);
+void queueDinoJump();
+void renderDinoGameView();

--- a/src/main.h
+++ b/src/main.h
@@ -13,6 +13,7 @@
 #include "nvs_flash.h"
 #include "nvs.h"
 #include <esp_task_wdt.h>
+#include <cmath>
 
 // #include "customFonts/lequahyper20pt7b.h" // Stylized font
 // #include <Fonts/FreeSansBold18pt7b.h>     // Larger font
@@ -50,6 +51,7 @@ enum View
   VIEW_FULLSCREEN_SPIRAL_PALETTE,
   VIEW_FULLSCREEN_SPIRAL_WHITE,
   VIEW_SCROLLING_TEXT,
+  VIEW_DINO_GAME,
   VIEW_PIXEL_DUST,
   VIEW_STATIC_COLOR,
   //VIEW_LGBT_FLAG
@@ -86,13 +88,13 @@ bool downloadFlag = false;
 
 ////////////////////// DEBUG MODE //////////////////////
 #define DEBUG_MODE 0          // Set to 1 to enable debug outputs
-#define DEBUG_MICROPHONE 1    // Set to 1 to enable microphone debug outputs
+#define DEBUG_MICROPHONE 0    // Set to 1 to enable microphone debug outputs
 #define DEBUG_ACCELEROMETER 0 // Set to 1 to enable accelerometer debug outputs
 #define DEBUG_BRIGHTNESS 0    // Set to 1 to enable brightness debug outputs
 #define DEBUG_VIEWS 0         // Set to 1 to enable views debug outputs
 #define DEBUG_VIEW_TIMING 0   // Set to 1 to enable views debug outputs
 #define DEBUG_FPS_COUNTER 0   // Set to 1 to enable FPS counter debug outputs
-#define DEBUG_PROXIMITY 0     // Set to 1 to enable proximity sensor debug logs
+#define DEBUG_PROXIMITY 1     // Set to 1 to enable proximity sensor debug logs
 #define TEXT_DEBUG 1          // Set to 1 to enable text debug outputs
 #define DEBUG_FLUID_EFFECT 0  // Set to 1 to enable fluid effect debug outputs
 #if DEBUG_MODE
@@ -275,12 +277,24 @@ constexpr unsigned long APDS_PROX_CACHE_MS = 50;     // Minimum spacing between 
 
 // float ambientLux = 0.0;
 static uint16_t lastKnownClearValue = 0; // Initialize to a sensible default
+static uint16_t lastKnownRedValue = 0;
+static uint16_t lastKnownGreenValue = 0;
+static uint16_t lastKnownBlueValue = 0;
+static float lastKnownLuxValue = 0.0f;
+static apds9960AGain_t apdsColorGain = APDS9960_AGAIN_4X;
+static uint16_t apdsIntegrationTimeMs = 10;
+constexpr uint16_t APDS_LUX_INTEGRATION_MIN_MS = 3;
+constexpr uint16_t APDS_LUX_INTEGRATION_MAX_MS = 100;
+constexpr uint16_t APDS_CLEAR_LOW_COUNT = 200;
+constexpr uint16_t APDS_CLEAR_HIGH_COUNT = 60000;
+constexpr float APDS_LUX_REFERENCE_INTEGRATION_MS = 10.0f;
+constexpr float APDS_LUX_REFERENCE_GAIN = 4.0f;
 float smoothedLux = 50.0f;
 const float luxSmoothingFactor = 0.15f;        // Adjust between 0.05 - 0.3
 float currentBrightness = 128.0f;              // NEW: Current brightness as a float for smoothing
-const float brightnessSmoothingFactor = 0.05f; // NEW: How quickly brightness adapts (0.01-0.1)
+const float brightnessSmoothingFactor = 0.90f; // NEW: How quickly brightness adapts (0.01-0.1)
 int lastBrightness = 0;
-const int brightnessThreshold = 3; // Only update if change > X
+const int brightnessThreshold = 1; // Only update if change > X
 unsigned long lastLuxUpdate = 0;
 const unsigned long luxUpdateInterval = 250; // Reduce read frequency to ease I2C contention
 
@@ -316,8 +330,8 @@ void setupAdaptiveBrightness()
   // Boost sensitivity for proximity and color for auto-brightness
   apds.setProxGain(APDS9960_PGAIN_8X);
   // apds.setLEDDrive(APDS9960_LEDDRIVE_100MA);
-  apds.setADCIntegrationTime(49); // ~50ms
-  // apds.setADCGain(APDS9960_AGAIN_8X);
+  apds.setADCGain(apdsColorGain);
+  apds.setADCIntegrationTime(apdsIntegrationTimeMs); // Tuning for lux range
   apds.enableProximity(true);                  // enable proximity mode
   apds.enableColor(true);                      // enable color mode
   apds.setProximityInterruptThreshold(0, 175); // set the interrupt threshold to fire when proximity reading goes above 175
@@ -333,14 +347,121 @@ void setupAdaptiveBrightness()
 }
 
 // Setup functions for adaptive brightness & proximity sensing using APDS9960:
-uint16_t getRawClearChannelValue()
+static float apdsGainToFloat(apds9960AGain_t gain)
+{
+  switch (gain)
+  {
+  case APDS9960_AGAIN_1X:
+    return 1.0f;
+  case APDS9960_AGAIN_4X:
+    return 4.0f;
+  case APDS9960_AGAIN_16X:
+    return 16.0f;
+  case APDS9960_AGAIN_64X:
+    return 64.0f;
+  default:
+    return 4.0f;
+  }
+}
+
+static apds9960AGain_t apdsStepGain(apds9960AGain_t gain, bool increase)
+{
+  switch (gain)
+  {
+  case APDS9960_AGAIN_1X:
+    return increase ? APDS9960_AGAIN_4X : APDS9960_AGAIN_1X;
+  case APDS9960_AGAIN_4X:
+    return increase ? APDS9960_AGAIN_16X : APDS9960_AGAIN_1X;
+  case APDS9960_AGAIN_16X:
+    return increase ? APDS9960_AGAIN_64X : APDS9960_AGAIN_4X;
+  case APDS9960_AGAIN_64X:
+    return increase ? APDS9960_AGAIN_64X : APDS9960_AGAIN_16X;
+  default:
+    return APDS9960_AGAIN_4X;
+  }
+}
+
+static float calculateLuxFromRgb(uint16_t r, uint16_t g, uint16_t b)
+{
+  float illuminance = (-0.32466f * r) + (1.57837f * g) + (-0.73191f * b);
+  if (illuminance < 0.0f)
+  {
+    illuminance = 0.0f;
+  }
+  return illuminance;
+}
+
+static float scaleLuxForSettings(float luxRaw)
+{
+  const float gain = apdsGainToFloat(apdsColorGain);
+  const float integrationMs = static_cast<float>(apdsIntegrationTimeMs);
+  if (gain <= 0.0f || integrationMs <= 0.0f)
+  {
+    return luxRaw;
+  }
+  const float scale = (APDS_LUX_REFERENCE_INTEGRATION_MS * APDS_LUX_REFERENCE_GAIN) / (integrationMs * gain);
+  return luxRaw * scale;
+}
+
+static void adjustApdsColorRange(uint16_t clear)
+{
+  bool changed = false;
+
+  if (clear >= APDS_CLEAR_HIGH_COUNT)
+  {
+    if (apdsColorGain != APDS9960_AGAIN_1X)
+    {
+      apdsColorGain = apdsStepGain(apdsColorGain, false);
+      changed = true;
+    }
+    else if (apdsIntegrationTimeMs > APDS_LUX_INTEGRATION_MIN_MS)
+    {
+      apdsIntegrationTimeMs = static_cast<uint16_t>(apdsIntegrationTimeMs / 2);
+      if (apdsIntegrationTimeMs < APDS_LUX_INTEGRATION_MIN_MS)
+      {
+        apdsIntegrationTimeMs = APDS_LUX_INTEGRATION_MIN_MS;
+      }
+      changed = true;
+    }
+  }
+  else if (clear <= APDS_CLEAR_LOW_COUNT)
+  {
+    if (apdsColorGain != APDS9960_AGAIN_64X)
+    {
+      apdsColorGain = apdsStepGain(apdsColorGain, true);
+      changed = true;
+    }
+    else if (apdsIntegrationTimeMs < APDS_LUX_INTEGRATION_MAX_MS)
+    {
+      apdsIntegrationTimeMs = static_cast<uint16_t>(apdsIntegrationTimeMs * 2);
+      if (apdsIntegrationTimeMs > APDS_LUX_INTEGRATION_MAX_MS)
+      {
+        apdsIntegrationTimeMs = APDS_LUX_INTEGRATION_MAX_MS;
+      }
+      changed = true;
+    }
+  }
+
+  if (changed)
+  {
+    apds.setADCGain(apdsColorGain);
+    apds.setADCIntegrationTime(apdsIntegrationTimeMs);
+#if DEBUG_BRIGHTNESS
+    Serial.printf("APDS range adjust: gain=%.0fx it=%ums\n",
+                  apdsGainToFloat(apdsColorGain),
+                  apdsIntegrationTimeMs);
+#endif
+  }
+}
+
+static void updateAmbientLightSample()
 {
   static unsigned long lastLogTime = 0;
   const unsigned long logInterval = 500; // Log 2 times per second
 
   if (!apdsInitialized)
   {
-    return lastKnownClearValue;
+    return;
   }
 
   if (apds.colorDataReady())
@@ -348,19 +469,54 @@ uint16_t getRawClearChannelValue()
     uint16_t r, g, b, c;
     apds.getColorData(&r, &g, &b, &c);
 
-#if DEBUG_BRIGHTNESS
-    Serial.print("Ambient light level (clear channel): ");
+    lastKnownRedValue = r;
+    lastKnownGreenValue = g;
+    lastKnownBlueValue = b;
     lastKnownClearValue = c;
-    Serial.println(c);
-#else
-    lastKnownClearValue = c; // Update last known good value
+
+    lastKnownLuxValue = scaleLuxForSettings(calculateLuxFromRgb(r, g, b));
+
+    adjustApdsColorRange(c);
+
+#if DEBUG_BRIGHTNESS
+    unsigned long now = millis();
+    if (now - lastLogTime >= logInterval)
+    {
+      lastLogTime = now;
+      Serial.printf("Ambient light: clear=%u lux=%.1f gain=%.0fx it=%ums\n",
+                    c,
+                    lastKnownLuxValue,
+                    apdsGainToFloat(apdsColorGain),
+                    apdsIntegrationTimeMs);
+    }
 #endif
-    return c; // Return the raw clear channel value
   }
-  else
+}
+
+uint16_t getRawClearChannelValue()
+{
+  updateAmbientLightSample();
+  return lastKnownClearValue;
+}
+
+float getAmbientLux()
+{
+  updateAmbientLightSample();
+  return lastKnownLuxValue;
+}
+
+uint16_t getAmbientLuxU16()
+{
+  float lux = getAmbientLux();
+  if (lux < 0.0f)
   {
-    return lastKnownClearValue; // Return the last good value if current not available
+    lux = 0.0f;
   }
+  if (lux > 65535.0f)
+  {
+    lux = 65535.0f;
+  }
+  return static_cast<uint16_t>(lux + 0.5f);
 }
 
 void updateAdaptiveBrightness()
@@ -372,11 +528,13 @@ void updateAdaptiveBrightness()
     if (lastBrightness != userBrightness)
     {
       dma_display->setBrightness8(userBrightness);
+      updateGlobalBrightnessScale(userBrightness);
       lastBrightness = userBrightness;
 #ifdef DEBUG_BRIGHTNESS
       Serial.printf(">>>> MANUAL: BRIGHTNESS SET TO %d <<<<\n", userBrightness);
 #endif
     }
+    currentBrightness = static_cast<float>(userBrightness);
     return;
   }
 
@@ -385,36 +543,35 @@ void updateAdaptiveBrightness()
     // Sensor unavailable: fall back to manual brightness without blocking FPS
     autoBrightnessEnabled = false;
     dma_display->setBrightness8(userBrightness);
+    updateGlobalBrightnessScale(userBrightness);
     lastBrightness = userBrightness;
+    currentBrightness = static_cast<float>(userBrightness);
     return;
   }
 
-  uint16_t rawClearValue = getRawClearChannelValue();
+  float currentLux = getAmbientLux();
 
-  float currentLuxEquivalent = static_cast<float>(rawClearValue);
-
-  smoothedLux = (luxSmoothingFactor * currentLuxEquivalent) + ((1.0f - luxSmoothingFactor) * smoothedLux);
+  smoothedLux = (luxSmoothingFactor * currentLux) + ((1.0f - luxSmoothingFactor) * smoothedLux);
 
   // --- CRITICAL CALIBRATION SECTION ---
 
-  const int min_brightness_output = 80;  // Fall back to user-set brightness when dark NOTE: use  userBrightness to revert to user setting
-  const int max_brightness_output = 255; // Preserve full-range capability
-  const float min_clear_for_map = 2.0f;  // Adjusted dark threshold
-  const float max_clear_for_map = 50.0f; // Adjusted bright threshold
-                                         // OBSERVE rawClearValue via Serial.print to refine these.
+  const int min_brightness_output = 80;   // Minimum display brightness
+  const int max_brightness_output = 255;  // Preserve full-range capability
+  const float min_lux_for_map = 5.0f;     // Dim indoor light
+  const float max_lux_for_map = 10000.0f; // Bright outdoor shade
 
   // ADJUST THESE VALUES:
-  // For earlier dimming (dims in brighter conditions):
-  // const float min_clear_for_map = 200.0f;           // Higher value = starts dimming earlier
+  // For earlier brightening (brighter in lower lux):
+  // const float min_lux_for_map = 20.0f;             // Higher value = starts brightening earlier
 
-  // For later dimming (only dims in very dark conditions):
-  // const float min_clear_for_map = 20.0f;            // Lower value = only dims when very dark
+  // For later brightening (only brightens in higher lux):
+  // const float min_lux_for_map = 1.0f;              // Lower value = only brightens when very dark
 
   // For reaching full brightness sooner (in less bright conditions):
-  // const float max_clear_for_map = 800.0f;           // Lower value = reaches max brightness sooner
+  // const float max_lux_for_map = 2000.0f;            // Lower value = reaches max brightness sooner
 
   // For reaching full brightness later (only in very bright conditions):
-  // const float max_clear_for_map = 2000.0f;          // Higher value = needs more light for full brightness
+  // const float max_lux_for_map = 20000.0f;           // Higher value = needs more light for full brightness
 
   // For different minimum brightness level:
   // const int min_brightness_output = 30;             // Fixed minimum instead of user brightness
@@ -424,25 +581,44 @@ void updateAdaptiveBrightness()
 
   // --- END CRITICAL CALIBRATION SECTION ---
 
-  long targetBrightnessLong = map(static_cast<long>(smoothedLux),
-                                  static_cast<long>(min_clear_for_map),
-                                  static_cast<long>(max_clear_for_map),
-                                  min_brightness_output,
-                                  max_brightness_output);
-  int targetBrightnessCalc = constrain(static_cast<int>(targetBrightnessLong), min_brightness_output, max_brightness_output);
+  float luxForMap = smoothedLux;
+  if (luxForMap < min_lux_for_map)
+  {
+    luxForMap = min_lux_for_map;
+  }
+
+  const float logMin = log10f(min_lux_for_map);
+  const float logMax = log10f(max_lux_for_map);
+  float t = (log10f(luxForMap) - logMin) / (logMax - logMin);
+  t = constrain(t, 0.0f, 1.0f);
+
+  int targetBrightnessCalc = static_cast<int>(
+      min_brightness_output + (t * static_cast<float>(max_brightness_output - min_brightness_output)) + 0.5f);
+  targetBrightnessCalc = constrain(targetBrightnessCalc, min_brightness_output, max_brightness_output);
+
+  const float targetBrightness = static_cast<float>(targetBrightnessCalc);
+  currentBrightness += brightnessSmoothingFactor * (targetBrightness - currentBrightness);
+  int smoothedBrightness = static_cast<int>(currentBrightness + 0.5f);
+  smoothedBrightness = constrain(smoothedBrightness, min_brightness_output, max_brightness_output);
 
 #if DEBUG_BRIGHTNESS
-  Serial.printf("ADAPT: RawC=%u, SmoothC=%.1f, TargetBr=%d, LastBr=%d, Thr=%d\n",
-                rawClearValue, smoothedLux, targetBrightnessCalc, lastBrightness, brightnessThreshold); // Corrected variable name
+  Serial.printf("ADAPT: Clear=%u, Lux=%.1f, SmoothLux=%.1f, TargetBr=%d, SmoothBr=%d, LastBr=%d, Thr=%d\n",
+                lastKnownClearValue,
+                currentLux,
+                smoothedLux,
+                targetBrightnessCalc,
+                smoothedBrightness,
+                lastBrightness,
+                brightnessThreshold);
 #endif
-  if (abs(targetBrightnessCalc - lastBrightness) >= brightnessThreshold)
+  if (abs(smoothedBrightness - lastBrightness) >= brightnessThreshold)
   {
-    uint8_t currentBrightness = static_cast<uint8_t>(targetBrightnessCalc);
-    dma_display->setBrightness8(currentBrightness);
-    updateGlobalBrightnessScale(currentBrightness);
-    lastBrightness = targetBrightnessCalc; // Update lastBrightness ONLY when a display change is made
+    uint8_t brightnessToApply = static_cast<uint8_t>(smoothedBrightness);
+    dma_display->setBrightness8(brightnessToApply);
+    updateGlobalBrightnessScale(brightnessToApply);
+    lastBrightness = smoothedBrightness; // Update lastBrightness ONLY when a display change is made
 #if DEBUG_BRIGHTNESS
-    Serial.printf(">>>> ADAPT: BRIGHTNESS SET TO %d <<<<\n", targetBrightnessCalc);
+    Serial.printf(">>>> ADAPT: BRIGHTNESS SET TO %d <<<<\n", smoothedBrightness);
 #endif
   }
   else
@@ -557,6 +733,8 @@ void applyConfigOptions()
     Serial.println("Auto brightness disabled. Applying user-set brightness.");
     dma_display->setBrightness8(userBrightness);
     updateGlobalBrightnessScale(userBrightness);
+    lastBrightness = userBrightness;
+    currentBrightness = static_cast<float>(userBrightness);
     Serial.printf("Applied manual brightness: %u\n", userBrightness);
   }
 


### PR DESCRIPTION
<p align="center">

  <img src="https://github.com/user-attachments/assets/125e2b13-76cf-43d8-b3ee-da7c9156d3cc" width="200">
  &nbsp;&nbsp;&nbsp;&nbsp;
  <img src="https://github.com/user-attachments/assets/ce0ac454-214d-4851-ac21-730beeecf22e" width="50">
  &nbsp;&nbsp;&nbsp;&nbsp;
  <img src="https://github.com/user-attachments/assets/0c3523df-8fe4-406f-9e76-fe668b5ae0a5" width="100">

</p>


This pull request introduces a new Dino game feature, improves BLE pairing state management for thread safety, and makes minor code and bitmap updates. The most significant changes are grouped below:

---

**New Feature: Dino Game**
- Added a full implementation of a Dino game, including `dino_game.cpp` and `dino_game.h`, which handles game state, rendering, collision detection, and user input for jump actions. The game is integrated into the main application (`main.cpp`). [[1]](diffhunk://#diff-acdaa141b210dbcb07e8aa54e9f75d5172e636745cc7a2b57c3b98a8da1ba13eR1-R329) [[2]](diffhunk://#diff-1bb989a8988ce9bcbe6541034a50e766085ae394f49cf37b01185bd8e8a55700R1-R7) [[3]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R22)

- Added a new cactus sprite bitmap to support the Dino game (`cactus` in `bitmaps.h`).

---

**BLE Pairing State Management Improvements**
- Refactored BLE pairing state handling to use thread-safe access with FreeRTOS critical sections. Introduced a `PairingSnapshot` struct and helper functions (`getPairingSnapshot`, `setPairingState`, `setPairingResetPending`, `isPairingResetPending`) in `ble_state.cpp` and `ble_state.h`. [[1]](diffhunk://#diff-d65a43c272946fe983ff1975d67344c784ae1ce89347482575c8dcd9b6a60a85R4-R14) [[2]](diffhunk://#diff-d65a43c272946fe983ff1975d67344c784ae1ce89347482575c8dcd9b6a60a85R38-R77) [[3]](diffhunk://#diff-cd405884bb849cd83c0689814c51609d0b126f638a1e14ad819e3671ceae149cR18-R30)

- Updated BLE server callbacks in `ble_server.cpp` to use the new pairing state functions, ensuring consistent and atomic state updates. Improved logic for pairing reset and bond deletion on disconnect. [[1]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5L27-R27) [[2]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5L37-R45) [[3]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5L59-R66) [[4]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5L73-R78) [[5]](diffhunk://#diff-ead7e3a9e4fe5bc82f1a103e81178250947cf08537d00de8af16bb910e63abe5L87-R93)

---

**Sensor and Brightness Handling**
- Changed the function used to read the ambient light sensor value in `ble_metrics.cpp` from `getRawClearChannelValue()` to `getAmbientLuxU16()` for more accurate lux readings.

- Added a debounce interval constant for pairing reset input handling in `main.cpp`.

---

**Bitmap and Miscellaneous Code Updates**
- Changed several bitmap and icon arrays in `bitmaps.h` from global to `static` to limit their scope and avoid potential linkage issues. [[1]](diffhunk://#diff-2fbeeb17a1ff30e2fa852a9d61483cb1706b110603c7c77b4663a18a743b3837L321-R326) [[2]](diffhunk://#diff-2fbeeb17a1ff30e2fa852a9d61483cb1706b110603c7c77b4663a18a743b3837L331-R336) [[3]](diffhunk://#diff-2fbeeb17a1ff30e2fa852a9d61483cb1706b110603c7c77b4663a18a743b3837L341-R346) [[4]](diffhunk://#diff-2fbeeb17a1ff30e2fa852a9d61483cb1706b110603c7c77b4663a18a743b3837L351-R356) [[5]](diffhunk://#diff-2fbeeb17a1ff30e2fa852a9d61483cb1706b110603c7c77b4663a18a743b3837L361-R366) [[6]](diffhunk://#diff-2fbeeb17a1ff30e2fa852a9d61483cb1706b110603c7c77b4663a18a743b3837L371-R376)

- Disabled microphone debug output by commenting out the `DEBUG_MICROPHONE` macro definition in `mic_config.h`.