### PR TITLE
Dev

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -261,13 +261,38 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: lumifur-firmware-release-${{ env.RELEASE_REF_NAME }}
-          
+
+      - name: Download raw firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-raw/
+          pattern: firmware-*
+
+      # NEW: Flatten + prefix raw files by environment
+      - name: Prefix raw firmware files
+        run: |
+          mkdir -p release-raw-prefixed
+          for env_dir in release-raw/firmware-*; do
+            if [ -d "$env_dir" ]; then
+              env_name=$(basename "$env_dir" | sed 's/firmware-//')
+              for file in "$env_dir"/*; do
+                if [ -f "$file" ]; then
+                  base=$(basename "$file")
+                  cp "$file" "release-raw-prefixed/${env_name}-${base}"
+                fi
+              done
+            fi
+          done
+          echo "Prefixed raw files:"
+          ls -la release-raw-prefixed
+
       - name: Attach to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             lumifur-firmware-*.tar.gz
             lumifur-firmware-*.zip
+            release-raw-prefixed/*
           body: |
             ## Firmware Artifacts
             

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ description = LumiFur HUB75 Protogen Controller Software
 
 [env]
 build_flags = 
-	-DFIRMWARE_VERSION=\"4.0.1\"
+	-DFIRMWARE_VERSION=\"4.0.2\"
 	-DDEVICE_MODEL=\"mps3\"
 	-DAPP_COMPAT_VERSION=\"6.3.2\"
 	-DBUILD_DATE=\"__DATE__\"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -997,7 +997,7 @@ void drawBluetoothStatusIcon()
   }
   if (clearW > 0 && clearH > 0)
   {
-    dma_display->fillRect(clearX, clearY, clearW, clearH, 0);
+    //dma_display->fillRect(clearX, clearY, clearW, clearH, 0);
   }
 
   drawXbm565(iconX, iconY, BLUETOOTH_BACKGROUND_WIDTH, BLUETOOTH_BACKGROUND_HEIGHT, bluetoothBackground, backgroundColor);
@@ -1991,19 +1991,20 @@ void drawBlush()
   const int blushWidth = 11;
   const int blushHeight = 13;
   const int blushCount = 3;
+  const int blushSpacing = blushWidth - 4;
   const int blushY = 1;
-  const int rightStartX = 23;
-  const int leftStartX = 72;
-  const int totalBlushWidth = blushWidth * blushCount;
+  const int rightStartX = 33;
+  const int leftStartX = 70;
+  const int totalBlushWidth = blushWidth + (blushCount - 1) * blushSpacing;
 
   // Clear only the blush area to prevent artifacts
-  dma_display->fillRect(rightStartX, blushY, totalBlushWidth, blushHeight, 0);
-  dma_display->fillRect(leftStartX, blushY, totalBlushWidth, blushHeight, 0);
+  // dma_display->fillRect(rightStartX, blushY, totalBlushWidth, blushHeight, 0);
+  // dma_display->fillRect(leftStartX, blushY, totalBlushWidth, blushHeight, 0);
 
   for (int i = 0; i < blushCount; ++i)
   {
-    drawXbm565(rightStartX + (i * blushWidth), blushY, blushWidth, blushHeight, blush, blushColor);
-    drawXbm565(leftStartX + (i * blushWidth), blushY, blushWidth, blushHeight, blushL, blushColor);
+    drawXbm565(rightStartX + (i * blushSpacing), blushY, blushWidth, blushHeight, blush, blushColor);
+    drawXbm565(leftStartX + (i * blushSpacing), blushY, blushWidth, blushHeight, blushL, blushColor);
   }
 }
 


### PR DESCRIPTION
This pull request makes several improvements to the firmware build and release workflow, updates the firmware version, and adjusts the display logic to prevent unnecessary clearing of certain screen regions. The most significant changes are grouped below:

**Build and Release Workflow Improvements:**

* Updated the GitHub Actions workflow in `.github/workflows/build-firmware.yml` to:
  * Download raw firmware artifacts and flatten/prefix them by environment for easier identification.
  * Attach these prefixed raw firmware files to the release alongside the regular archives.
  * Upgrade the `softprops/action-gh-release` action from v1 to v2.

**Firmware Version Update:**

* Bumped the firmware version from `4.0.1` to `4.0.2` in `platformio.ini`.

**Display Logic Adjustments:**

* Commented out rectangle-clearing code in `drawBluetoothStatusIcon()` and `drawBlush()` in `src/main.cpp` to prevent unnecessary clearing, which may help reduce flickering or artifacts. [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L1000-R1000) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R1994-R2007)
* Refined blush drawing logic in `drawBlush()` by adjusting spacing and start positions for improved visual alignment.