### PR TITLE
fix: update face view frame interval to improve pacing

### DIFF
--- a/include/perf_tuning.h
+++ b/include/perf_tuning.h
@@ -19,7 +19,7 @@
 
 // Face/plasma pacing
 #ifndef LF_FACE_VIEW_FRAME_INTERVAL_MS
-#define LF_FACE_VIEW_FRAME_INTERVAL_MS 8UL
+#define LF_FACE_VIEW_FRAME_INTERVAL_MS 10UL
 #endif
 
 // BLE worker sizing


### PR DESCRIPTION
This pull request makes a minor adjustment to the frame interval for face/plasma pacing. The interval has been changed from 8 milliseconds to 10 milliseconds in the `perf_tuning.h` configuration.

- Increased the value of `LF_FACE_VIEW_FRAME_INTERVAL_MS` from 8ms to 10ms to adjust the pacing interval for face/plasma rendering.