### PR TITLE
feat: add debug configuration and user preferences management for ble indicator & associated display icon

### DIFF
--- a/src/config/debug_config.h
+++ b/src/config/debug_config.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#ifndef DEBUG_MODE
+#define DEBUG_MODE 0          // Set to 1 to enable debug outputs
+#endif
+#ifndef DEBUG_MICROPHONE
+#define DEBUG_MICROPHONE 0    // Set to 1 to enable microphone debug outputs
+#endif
+#ifndef DEBUG_ACCELEROMETER
+#define DEBUG_ACCELEROMETER 0 // Set to 1 to enable accelerometer debug outputs
+#endif
+#ifndef DEBUG_BRIGHTNESS
+#define DEBUG_BRIGHTNESS 0    // Set to 1 to enable brightness debug outputs
+#endif
+#ifndef DEBUG_VIEWS
+#define DEBUG_VIEWS 0         // Set to 1 to enable views debug outputs
+#endif
+#ifndef DEBUG_VIEW_TIMING
+#define DEBUG_VIEW_TIMING 0   // Set to 1 to enable view timing debug outputs
+#endif
+#ifndef DEBUG_FPS_COUNTER
+#define DEBUG_FPS_COUNTER 0   // Set to 1 to enable FPS counter debug outputs
+#endif
+#ifndef DEBUG_PROXIMITY
+#define DEBUG_PROXIMITY 0     // Set to 1 to enable proximity sensor debug logs
+#endif
+#ifndef TEXT_DEBUG
+#define TEXT_DEBUG 0          // Set to 1 to enable text debug outputs
+#endif
+#ifndef DEBUG_FLUID_EFFECT
+#define DEBUG_FLUID_EFFECT 0  // Set to 1 to enable fluid effect debug outputs
+#endif
+#ifndef DEBUG_VIDEO_PLAYER
+#define DEBUG_VIDEO_PLAYER 0  // Set to 1 to enable video player debug logs and overlay
+#endif
+#ifndef DEBUG_DISABLE_BLE_INDICATOR_LIGHT
+#define DEBUG_DISABLE_BLE_INDICATOR_LIGHT 1 // Set to 1 to force the BLE NeoPixel indicator off
+#endif
+#ifndef DEBUG_DISABLE_BLE_STATUS_ICON
+#define DEBUG_DISABLE_BLE_STATUS_ICON 1 // Set to 1 to hide the on-screen BLE status icon
+#endif
+
+#if DEBUG_MODE
+#define DEBUG_BLE
+#endif
+
+#if DEBUG_PROXIMITY
+#define LOG_PROX(...) Serial.printf(__VA_ARGS__)
+#define LOG_PROX_LN(msg) Serial.println(msg)
+#else
+#define LOG_PROX(...) \
+  do                  \
+  {                   \
+  } while (0)
+#define LOG_PROX_LN(msg) \
+  do                     \
+  {                      \
+  } while (0)
+#endif

--- a/src/config/debug_config.h
+++ b/src/config/debug_config.h
@@ -34,10 +34,10 @@
 #define DEBUG_VIDEO_PLAYER 0  // Set to 1 to enable video player debug logs and overlay
 #endif
 #ifndef DEBUG_DISABLE_BLE_INDICATOR_LIGHT
-#define DEBUG_DISABLE_BLE_INDICATOR_LIGHT 1 // Set to 1 to force the BLE NeoPixel indicator off
+#define DEBUG_DISABLE_BLE_INDICATOR_LIGHT 0 // Set to 1 to force the BLE NeoPixel indicator off
 #endif
 #ifndef DEBUG_DISABLE_BLE_STATUS_ICON
-#define DEBUG_DISABLE_BLE_STATUS_ICON 1 // Set to 1 to hide the on-screen BLE status icon
+#define DEBUG_DISABLE_BLE_STATUS_ICON 0 // Set to 1 to hide the on-screen BLE status icon
 #endif
 
 #if DEBUG_MODE

--- a/src/config/userPreferences.h
+++ b/src/config/userPreferences.h
@@ -1,0 +1,174 @@
+#pragma once
+#include <Preferences.h>
+
+static constexpr char NAMESPACE[] = "LumiFur";
+static constexpr char KEY_LAST[] = "lastView";
+
+// Returns a reference to a static Preferences instance.
+inline Preferences &getPrefs()
+{
+  static Preferences prefs;
+  return prefs;
+}
+
+// Initializes the Preferences system; call this in setup().
+inline void initPreferences()
+{
+  // Open the "LumiFur" namespace in read/write mode.
+  getPrefs().begin("LumiFur", false);
+}
+
+// Debug mode functions
+inline bool getDebugMode()
+{
+  return getPrefs().getBool("debug", true);
+}
+inline void setDebugMode(bool debugMode)
+{
+  getPrefs().putBool("debug", debugMode);
+}
+
+// Brightness functions
+inline int getUserBrightness()
+{
+  return getPrefs().getInt("brightness", 255); // Default to 255 (full brightness)
+}
+inline void setUserBrightness(int brightness)
+{
+  getPrefs().putInt("brightness", brightness);
+}
+
+// Blink mode functions
+inline bool getBlinkMode()
+{
+  return getPrefs().getBool("blinkmode", true);
+}
+inline void setBlinkMode(bool blinkMode)
+{
+  getPrefs().putBool("blinkmode", blinkMode);
+}
+
+// Sleep mode functions
+inline bool getSleepMode()
+{
+  return getPrefs().getBool("sleepmode", true);
+}
+inline void setSleepMode(bool sleepMode)
+{
+  getPrefs().putBool("sleepmode", sleepMode);
+}
+
+// Dizzy mode functions
+inline bool getDizzyMode()
+{
+  return getPrefs().getBool("dizzymode", true);
+}
+inline void setDizzyMode(bool dizzyMode)
+{
+  getPrefs().putBool("dizzymode", dizzyMode);
+}
+
+// Auto brightness functions
+inline bool getAutoBrightness()
+{
+  return getPrefs().getBool("autobrightness", true);
+}
+inline void setAutoBrightness(bool autoBrightness)
+{
+  getPrefs().putBool("autobrightness", autoBrightness);
+}
+
+// Accelerometer functions
+inline bool getAccelerometerEnabled()
+{
+  return getPrefs().getBool("accelerometer", true);
+}
+inline void setAccelerometerEnabled(bool enabled)
+{
+  getPrefs().putBool("accelerometer", enabled);
+}
+
+// Aurora mode functions
+inline bool getAuroraMode()
+{
+  return getPrefs().getBool("auroramode", true);
+}
+inline void setAuroraMode(bool enabled)
+{
+  getPrefs().putBool("auroramode", enabled);
+}
+
+inline bool getStaticColorMode()
+{
+  return getPrefs().getBool("staticcolormode", false);
+}
+inline void setStaticColorMode(bool enabled)
+{
+  getPrefs().putBool("staticcolormode", enabled);
+}
+
+inline uint8_t getLastView()
+{
+  return getPrefs().getUChar(KEY_LAST, 0);
+}
+
+inline void saveLastView(uint8_t v)
+{
+  getPrefs().putUChar(KEY_LAST, v);
+}
+
+inline void saveUserText(const String &text)
+{
+  getPrefs().putString("userText", text);
+}
+
+inline String getUserText()
+{
+  return getPrefs().getString("userText", "");
+}
+
+inline void saveScrollSpeed(uint16_t speed)
+{
+  getPrefs().putUShort("scrollSpeed", speed);
+}
+
+inline uint16_t getScrollSpeed()
+{
+  return getPrefs().getUShort("scrollSpeed", 4);
+}
+
+inline void saveStrobeColorPreference(const String &text)
+{
+  getPrefs().putString("strobeColor", text);
+}
+
+inline String getStrobeColorPreference()
+{
+  return getPrefs().getString("strobeColor", "FFFFFF");
+}
+
+inline void saveStrobeSpeedPreference(uint16_t speedMs)
+{
+  getPrefs().putUShort("strobeSpeed", speedMs);
+}
+
+inline uint16_t getStrobeSpeedPreference()
+{
+  return getPrefs().getUShort("strobeSpeed", 120);
+}
+
+inline void saveSelectedColor(const String &text)
+{
+  getPrefs().putString("selectedColor", text);
+}
+
+inline String getSelectedColor()
+{
+  return getPrefs().getString("selectedColor", "");
+}
+
+// Clear all preferences - Implement feature to reset controller to default settings
+inline void clearPreferences()
+{
+  getPrefs().clear();
+}


### PR DESCRIPTION
## Summary
This change adds build-time config overrides for BLE visual indicators so they can be disabled without editing `main.cpp`.

## Problem
The Bluetooth status rune can reappear when the LumiFur app is connected with Live Activities enabled and the iOS device goes to sleep. That is distracting while suiting, especially when the phone cannot be kept awake continuously.

The current workaround is to manually comment out Bluetooth status icon code in `main.cpp` before compiling and uploading.

## Solution
Add two config flags in `src/config/debug_config.h`:

- `DEBUG_DISABLE_BLE_STATUS_ICON`
- `DEBUG_DISABLE_BLE_INDICATOR_LIGHT`

When enabled, these suppress only the BLE visual indicators:

- the on-screen Bluetooth rune/status icon
- the BLE NeoPixel indicator light

BLE connection state, advertising, pairing flow, and passkey overlay behavior remain unchanged.

## Motivation
### Is your feature request related to a problem? Please describe.
Bluetooth status icon returns even when LumiFur app is connected with live activities enabled when iOS device sleeps. This is annoying while suiting and not able to keep iOS device awake at all times.

### Describe the solution you'd like
An option to disable the Bluetooth rune status icon completely without having to edit `main.cpp`.

### Describe alternatives you've considered
Currently commenting out all lines in `main.cpp` related to `BluetoothStatusIcon` before compiling and uploading.

### Additional Context
Pairing Passkey overlay is not impacted by disabling the `BluetoothStatusIcon` in testing. No other BLE functions appear to be impacted either.

## Implementation
- Added BLE visual override flags to `src/config/debug_config.h`
- Gated `drawBluetoothStatusIcon()` behind `DEBUG_DISABLE_BLE_STATUS_ICON`
- Gated Bluetooth overlay refresh logic behind `DEBUG_DISABLE_BLE_STATUS_ICON`
- Gated `handleBLEStatusLED()` output behind `DEBUG_DISABLE_BLE_INDICATOR_LIGHT`
- Left pairing passkey overlay behavior untouched

## Testing
- Built successfully with `py -m platformio run -e adafruit_matrixportal_esp32s3`
- Confirmed pairing passkey overlay is still shown when expected
- Confirmed no observed impact to BLE connectivity or other BLE functions when the icon override is enabled




Special thanks to @willowpup1312 for suggesting this feature.