### PR TITLE
New Hardware Board Definition to Remap G and B Pins for Waveshare Displays

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,7 +8,7 @@
         "platformio.platformio-ide"
     ],
     "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack",
-        "ms-vscode.cmake-tools"
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools-extension-pack"
     ]
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -101,6 +101,7 @@ upload_protocol = esptool
 ;  --after=hard_reset
 monitor_filters = 
 
+
 [env:adafruit_matrixportal_esp32s3_waveshare] ;MatrixPortal ESP32-S3 with Waveshare Displays
 platform = espressif32
 board = adafruit_matrixportal_esp32s3
@@ -125,6 +126,8 @@ build_flags =
 	-DARDUINO_USB_MODE=1
 	-DARDUINO_USB_CDC_ON_BOOT=1
 	-DARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3_Waveshare ;Defines board name for deviceconfig files without requiring a custom PIO environment
+upload_protocol = esptool
+;upload_flags =
 ;  --before=default_reset
 ;  --after=hard_reset
 monitor_filters = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -101,6 +101,37 @@ upload_protocol = esptool
 ;  --after=hard_reset
 monitor_filters = 
 
+[env:adafruit_matrixportal_esp32s3_waveshare]
+platform = espressif32
+board = adafruit_matrixportal_esp32s3
+framework = arduino
+monitor_speed = 115200
+board_build.filesystem = fatfs
+extra_scripts = pre:tools/platformio/prepare_video_assets.py
+monitor_dtr = 0
+monitor_rts = 0
+lib_deps = 
+	adafruit/Adafruit GFX Library@^1.12.0
+	adafruit/Adafruit NeoPixel@^1.12.5
+	adafruit/Adafruit LIS3DH@^1.3.0
+	adafruit/Adafruit APDS9960 Library@^1.3.0
+	h2zero/NimBLE-Arduino@^2.2.3
+	mrfaptastic/ESP32 HUB75 LED MATRIX PANEL DMA Display@^3.0.12
+	fastled/FastLED@^3.9.14
+	adafruit/Adafruit PixelDust@^1.1.3
+build_flags = 
+	-O2
+	-DCONFIG_BT_NIMBLE_PINNED_TO_CORE=1
+	-DARDUINO_USB_MODE=1
+	-DARDUINO_USB_CDC_ON_BOOT=1
+	-DARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3_Waveshare
+upload_protocol = esptool
+;upload_flags =
+;  --before=default_reset
+;  --after=hard_reset
+monitor_filters = 
+
+
 [env:dev-fast]
 extends = env:adafruit_matrixportal_esp32s3
 build_type = debug

--- a/platformio.ini
+++ b/platformio.ini
@@ -101,7 +101,7 @@ upload_protocol = esptool
 ;  --after=hard_reset
 monitor_filters = 
 
-[env:adafruit_matrixportal_esp32s3_waveshare]
+[env:adafruit_matrixportal_esp32s3_waveshare] ;MatrixPortal ESP32-S3 with Waveshare Displays
 platform = espressif32
 board = adafruit_matrixportal_esp32s3
 framework = arduino
@@ -124,9 +124,7 @@ build_flags =
 	-DCONFIG_BT_NIMBLE_PINNED_TO_CORE=1
 	-DARDUINO_USB_MODE=1
 	-DARDUINO_USB_CDC_ON_BOOT=1
-	-DARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3_Waveshare
-upload_protocol = esptool
-;upload_flags =
+	-DARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3_Waveshare ;Defines board name for deviceconfig files without requiring a custom PIO environment
 ;  --before=default_reset
 ;  --after=hard_reset
 monitor_filters = 

--- a/src/hardware/deviceConfig.cpp
+++ b/src/hardware/deviceConfig.cpp
@@ -1,6 +1,9 @@
 #include "hardware/deviceConfig.h"
 
-#if defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3)
+#if defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3_Waveshare)
+Adafruit_APDS9960 apds;
+Adafruit_NeoPixel statusPixel(1, STATUS_LED_PIN, NEO_GRB + NEO_KHZ800);
+#elif defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3)
 Adafruit_APDS9960 apds;
 Adafruit_NeoPixel statusPixel(1, STATUS_LED_PIN, NEO_GRB + NEO_KHZ800);
 #endif

--- a/src/hardware/deviceConfig.cpp
+++ b/src/hardware/deviceConfig.cpp
@@ -1,6 +1,6 @@
 #include "hardware/deviceConfig.h"
 
-#if defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3_Waveshare)
+#if defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3_Waveshare) // MatrixPortal ESP32-S3 with Waveshare Displays. Has to Be Placed Before ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3 or the hardware config will not apply properly.
 Adafruit_APDS9960 apds;
 Adafruit_NeoPixel statusPixel(1, STATUS_LED_PIN, NEO_GRB + NEO_KHZ800);
 #elif defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3)

--- a/src/hardware/deviceConfig.h
+++ b/src/hardware/deviceConfig.h
@@ -46,13 +46,13 @@ class VirtualMatrixPanel;
 #if defined(_VARIANT_MATRIXPORTAL_M4_) // MatrixPortal M4
 #define BUTTON_UP 2
 #define BUTTON_DOWN 3
-#elif defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3_Waveshare) // MatrixPortal ESP32-S3 with Waveshare Displays
+#elif defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3_Waveshare) // MatrixPortal ESP32-S3 with Waveshare Displays. Has to Be Placed Before ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3 or the hardware config will not apply properly.
 #define R1_PIN 42
-#define G1_PIN 40
-#define B1_PIN 41
+#define G1_PIN 40 //Swapped with 41
+#define B1_PIN 41 //Swapped wth 40
 #define R2_PIN 38
-#define G2_PIN 37
-#define B2_PIN 39
+#define G2_PIN 37 //Swapped with 39
+#define B2_PIN 39 //Swapped with 37
 #define A_PIN 45
 #define B_PIN 36
 #define C_PIN 48

--- a/src/hardware/deviceConfig.h
+++ b/src/hardware/deviceConfig.h
@@ -46,6 +46,40 @@ class VirtualMatrixPanel;
 #if defined(_VARIANT_MATRIXPORTAL_M4_) // MatrixPortal M4
 #define BUTTON_UP 2
 #define BUTTON_DOWN 3
+#elif defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3_Waveshare) // MatrixPortal ESP32-S3 with Waveshare Displays
+#define R1_PIN 42
+#define G1_PIN 40
+#define B1_PIN 41
+#define R2_PIN 38
+#define G2_PIN 37
+#define B2_PIN 39
+#define A_PIN 45
+#define B_PIN 36
+#define C_PIN 48
+#define D_PIN 35
+#define E_PIN 21
+#define LAT_PIN 47
+#define OE_PIN 14
+#define CLK_PIN 2
+#define PIN_E 21 // E pin for 64px high panels
+// Button pins
+#define BUTTON_UP 6
+#define BUTTON_DOWN 7
+#include <Wire.h>              // For I2C sensors
+#define APDS_SDA_PIN 16 // STEMMA QT SDA on MatrixPortal S3
+#define APDS_SCL_PIN 17 // STEMMA QT SCL on MatrixPortal S3
+// #include <SPI.h>                  // For SPI sensors
+#include "Adafruit_APDS9960.h" // Library for built-in gesture sensor
+// the pin that the interrupt is attached to
+// #define INT_PIN 3
+#define APDS_AVAILABLE
+extern Adafruit_APDS9960 apds;
+#include <Adafruit_LIS3DH.h>   // Library for built-in For accelerometer
+#include <Adafruit_NeoPixel.h> // Library for built-in NeoPixel
+#define STATUS_LED_PIN 4
+extern Adafruit_NeoPixel statusPixel;
+#include "core/mic/mic_pins.h"
+#define ACCEL_AVAILABLE
 #elif defined(ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3) // MatrixPortal ESP32-S3
 #define R1_PIN 42
 #define G1_PIN 41


### PR DESCRIPTION
Changes for Waveshare displays on MatrixPortal S3

Here's a pull request template:

# Pull Request Template

## Description

For some reason, the pins for G and B are switched on Waveshare HUB75 displays despite the pinouts provided by the manufacturer appearing to meet the standard HUB75 pinout. When using a Waveshare display with the MatrixPortal S3 the colors will be incorrect with G and B values swapped without changes to the hardware pin definitions or physically swapping lines in the IDC connectors. This change simply adds another board definition for the MatrixPortal S3 with Waveshare displays. 

Fixes # N/A, no bug report submitted for this issue 

## Type of Change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran all test requested in contribution documentation. Verified change is effective on hardware (MatrixPortal S3 with Waveshare displays) and that the existing board definition for the MatrixPortal S3 still works as expected. When building under the ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3_Waveshare environment display colors are correct without needing to change the device config file. When building under the original ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3 environment the G and B colors are swapped on the displays (this is expected behavior and proves that the build for the ARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3 environment is unmodified).

## Checklist

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [x ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective
- [x ] New and existing unit tests pass locally with my changes